### PR TITLE
Further corrections to work with current sklearn

### DIFF
--- a/monoensemble/mono_forest.py
+++ b/monoensemble/mono_forest.py
@@ -433,7 +433,7 @@ class MonoRandomForestClassifier(ForestClassifier):
 
         for estimator in self.estimators_:
             unsampled_indices = _generate_unsampled_indices(
-                estimator.random_state, n_samples)
+                estimator.random_state, n_samples, 1)
             p_estimator = estimator.predict_proba(X[unsampled_indices, :],
                                                   check_input=False)
 

--- a/monoensemble/mono_gradient_boosting.py
+++ b/monoensemble/mono_gradient_boosting.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """Monotone Gradient Boosted Trees
 
 This module contains methods for fitting gradient boosted trees for
@@ -1008,7 +1008,7 @@ def apply_rules_tree(   X,
                         ):
     X_leaf_node_ids = tree.apply(X, check_input=False).astype(np.int32)
     # cache X_leaf_node_ids for each node
-    num_nodes=tree_.node_count
+    num_nodes=tree.tree_.node_count
     node_members=np.zeros([num_nodes,X.shape[0]],dtype=np.int32)
     node_member_count=np.zeros(num_nodes,dtype=np.int32)
     for inode in np.unique(X_leaf_node_ids):
@@ -1018,10 +1018,10 @@ def apply_rules_tree(   X,
     rule_mask = np.zeros(
             [X.shape[0], rule_lower_corners.shape[0]], dtype=np.int32)
     apply_rules_from_tree_c(X,
-                            tree_.children_left,
-                            tree_.children_right,
-                            tree_.feature,
-                            tree_.threshold,
+                            tree.tree_.children_left,
+                            tree.tree_.children_right,
+                            tree.tree_.feature,
+                            tree.tree_.threshold,
                             node_members,
                             node_member_count,
                             rule_upper_corners.shape[1],
@@ -1039,7 +1039,7 @@ def apply_rules_tree_sorted(   X,
 
     X_leaf_node_ids = tree.apply(X, check_input=False).astype(np.int32)
     # cache X_leaf_node_ids for each node
-    num_nodes=tree_.node_count
+    num_nodes=tree.tree_.node_count
     node_members=np.zeros([num_nodes,X.shape[0]],dtype=np.int32,order='C')
     node_member_count=np.zeros(num_nodes,dtype=np.int32,order='C')
     node_member_start=np.zeros(num_nodes,dtype=np.int32,order='C')
@@ -1069,10 +1069,10 @@ def apply_rules_tree_sorted(   X,
                             X_by_node_sorted,
                             X_by_node_sorted_idx,
                             X_by_node_sorted_idx_posns,
-                            tree_.children_left.astype(np.int32),
-                            tree_.children_right.astype(np.int32),
-                            tree_.feature.astype(np.int32),
-                            tree_.threshold.astype(np.float64),
+                            tree.tree_.children_left.astype(np.int32),
+                            tree.tree_.children_right.astype(np.int32),
+                            tree.tree_.feature.astype(np.int32),
+                            tree.tree_.threshold.astype(np.float64),
                             node_members,
                             node_member_count,
                             node_member_start,
@@ -1536,8 +1536,8 @@ class BaseMonoGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
                 min_impurity_split=self.min_impurity_split,
                 max_features=self.max_features,
                 max_leaf_nodes=self.max_leaf_nodes,
-                random_state=random_state,
-                presort=self.presort)  
+                random_state=random_state)
+                #presort=self.presort)  
 
             if self.subsample < 1.0:
                 # no inplace multiplication!
@@ -1561,7 +1561,7 @@ class BaseMonoGradientBoosting(six.with_metaclass(ABCMeta, BaseEnsemble)):
              leaf_upper_corners,
              rule_upper_corners,
              rule_lower_corners,
-             dist_feats] = extract_rules_from_tree_cython(tree_,
+             dist_feats] = extract_rules_from_tree_cython(tree.tree_,
                                                    X.shape[1],
                                                    self.incr_feats,
                                                    self.decr_feats)


### PR DESCRIPTION
Further corrections are necessary to make 'monoensemble' work with current sklearn. The main ones that I need your attention to:

(1) the "presort" and "X_idx_sorted" sklearn parameters have been deprecated. See, respectively:
https://github.com/scikit-learn/scikit-learn/pull/14907
https://github.com/scikit-learn/scikit-learn/issues/16818
Since I don't know how exactly do you prefer to handle that in light of the suggestions in the first link above, in order to at least leave 'monoensemble' in a working state, the only thing I did was to comment out "presort=self.presort" from line 1540 in the file 'mono_gradient_boosting.py'. But a more definitive solution will be necessary, since right now a FutureWarning is issued every iteration due to "X_idx_sorted" deprecation (which, besides being annoying, means that the code will soon be broken again if "X_idx_sorted" is not eliminated from the code base).

(2) in the line 436, from file 'mono_forest.py',  the "_generate_unsampled_indices" throws an error because that function now has an extra parameters, 'n_samples_bootstrap':
https://github.com/scikit-learn/scikit-learn/blob/4b8cd880397f279200b8faf9c75df13801cb45b7/sklearn/ensemble/_forest.py#L123
I obviously also do not know what is your preference here, but given the implementation in that link, it seems safe to assume that thus far your code was operating with the equivalent of 'n_samples_bootstrap = 1'. So that is what I imposed for now in the line 436, from file 'mono_forest.py'.